### PR TITLE
feat: add search and fetch handlers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,9 @@ import {
   ListResourcesRequestSchema,
   ListResourceTemplatesRequestSchema,
   ReadResourceRequestSchema,
+  // TODO: Replace 'any' typings once SDK exposes proper types
+  SearchRequestSchema,
+  FetchRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { AsanaClientWrapper } from './asana-client-wrapper.js'
 import { createPromptHandlers } from './prompt-handler.js';
@@ -68,6 +71,20 @@ async function main() {
   server.setRequestHandler(ListResourcesRequestSchema, resourceHandlers.listResources);
   server.setRequestHandler(ListResourceTemplatesRequestSchema, resourceHandlers.listResourceTemplates);
   server.setRequestHandler(ReadResourceRequestSchema, resourceHandlers.readResource);
+
+  // Add search and fetch handlers
+  const searchHandler = async (_request: any): Promise<any> => {
+    console.error("Received SearchRequest:", _request);
+    return { items: [] };
+  };
+
+  const fetchHandler = async (_request: any): Promise<any> => {
+    console.error("Received FetchRequest:", _request);
+    return { resource: null };
+  };
+
+  server.setRequestHandler(SearchRequestSchema, searchHandler);
+  server.setRequestHandler(FetchRequestSchema, fetchHandler);
 
   const transport = new StdioServerTransport();
   console.error("Connecting server to transport...");


### PR DESCRIPTION
## Summary
- import `SearchRequestSchema` and `FetchRequestSchema`
- add placeholder `searchHandler` and `fetchHandler`
- register search and fetch handlers in server setup

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: No matching export in sdk for SearchRequestSchema/FetchRequestSchema)


------
https://chatgpt.com/codex/tasks/task_b_68bb0a25579c8325af99f52907b3a5df