### PR TITLE
feat: add connector search handler

### DIFF
--- a/src/connector-handler.ts
+++ b/src/connector-handler.ts
@@ -1,0 +1,50 @@
+import { AsanaClientWrapper } from './asana-client-wrapper.js';
+
+export function searchHandler(asanaClient: AsanaClientWrapper) {
+  return async (request: any): Promise<any> => {
+    console.error("Received SearchRequest:", request);
+
+    const params = request.params || {};
+    const { type, workspace, query, page } = params;
+
+    if (!type || !workspace || !query) {
+      throw new Error("Missing required parameters: type, workspace, or query");
+    }
+
+    const limit = page?.limit;
+    const cursor = page?.cursor;
+    const opts: any = {};
+    if (limit !== undefined) opts.limit = limit;
+    if (cursor !== undefined) opts.offset = cursor;
+
+    let results: any[] = [];
+    if (type === 'project') {
+      results = await asanaClient.searchProjects(workspace, query, false, opts);
+    } else if (type === 'task') {
+      results = await asanaClient.searchTasks(workspace, { text: query, ...opts });
+    } else {
+      throw new Error(`Unsupported search type: ${type}`);
+    }
+
+    const items = results.map((item: any) => ({
+      id: item.gid,
+      title: item.name,
+      summary: item.notes || ''
+    }));
+
+    let response: any = { items };
+    if (limit && results.length === limit) {
+      const nextCursor = cursor ? String(cursor) : String(results.length);
+      response.nextPage = { cursor: nextCursor };
+    }
+
+    return response;
+  };
+}
+
+export function fetchHandler(_asanaClient: AsanaClientWrapper) {
+  return async (request: any): Promise<any> => {
+    console.error("Received FetchRequest:", request);
+    return { resource: null };
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,13 +11,12 @@ import {
   ListResourcesRequestSchema,
   ListResourceTemplatesRequestSchema,
   ReadResourceRequestSchema,
-  // TODO: Replace 'any' typings once SDK exposes proper types
-  SearchRequestSchema,
-  FetchRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { AsanaClientWrapper } from './asana-client-wrapper.js'
+import { z } from "zod";
+import { AsanaClientWrapper } from './asana-client-wrapper.js';
 import { createPromptHandlers } from './prompt-handler.js';
 import { createResourceHandlers } from './resource-handler.js';
+import { searchHandler, fetchHandler } from './connector-handler.js';
 
 async function main() {
   const asanaToken = process.env.ASANA_ACCESS_TOKEN;
@@ -73,18 +72,10 @@ async function main() {
   server.setRequestHandler(ReadResourceRequestSchema, resourceHandlers.readResource);
 
   // Add search and fetch handlers
-  const searchHandler = async (_request: any): Promise<any> => {
-    console.error("Received SearchRequest:", _request);
-    return { items: [] };
-  };
-
-  const fetchHandler = async (_request: any): Promise<any> => {
-    console.error("Received FetchRequest:", _request);
-    return { resource: null };
-  };
-
-  server.setRequestHandler(SearchRequestSchema, searchHandler);
-  server.setRequestHandler(FetchRequestSchema, fetchHandler);
+  const SearchRequestSchema = z.any();
+  const FetchRequestSchema = z.any();
+  server.setRequestHandler(SearchRequestSchema, searchHandler(asanaClient));
+  server.setRequestHandler(FetchRequestSchema, fetchHandler(asanaClient));
 
   const transport = new StdioServerTransport();
   console.error("Connecting server to transport...");


### PR DESCRIPTION
## Summary
- implement search handler routing project and task searches through AsanaClientWrapper
- wire connector search/fetch handlers into server

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bb0b74f41c832596587438ce8721b2