### PR TITLE
feat: add Asana connector fetch handler

### DIFF
--- a/src/connector-handler.ts
+++ b/src/connector-handler.ts
@@ -42,9 +42,44 @@ export function searchHandler(asanaClient: AsanaClientWrapper) {
   };
 }
 
-export function fetchHandler(_asanaClient: AsanaClientWrapper) {
+export function fetchHandler(asanaClient: AsanaClientWrapper) {
   return async (request: any): Promise<any> => {
     console.error("Received FetchRequest:", request);
-    return { resource: null };
+
+    const params = request.params || {};
+    const { id, type } = params;
+
+    if (!id || !type) {
+      throw new Error("Missing required parameters: id or type");
+    }
+
+    let resource: any;
+    if (type === 'task') {
+      const task = await asanaClient.getTask(id);
+      resource = {
+        id: task.gid,
+        type: 'task',
+        title: task.name,
+        content: {
+          mimeType: 'application/json',
+          text: JSON.stringify(task, null, 2)
+        }
+      };
+    } else if (type === 'project') {
+      const project = await asanaClient.getProject(id);
+      resource = {
+        id: project.gid,
+        type: 'project',
+        title: project.name,
+        content: {
+          mimeType: 'application/json',
+          text: JSON.stringify(project, null, 2)
+        }
+      };
+    } else {
+      throw new Error(`Unsupported fetch type: ${type}`);
+    }
+
+    return { resource };
   };
 }


### PR DESCRIPTION
## Summary
- implement fetch handler to retrieve tasks or projects by id
- return structured FetchResponse including JSON content for ChatGPT consumption

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68bb0ff020708325a4996eb3c6b7e573